### PR TITLE
feat: add CryptoHFTData historical feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ canonical changelog for the repository.
 
 ## [Unreleased]
 
+### Added
+
+- Added the optional ``CryptoHFTData`` historical crypto feed for exchange-native trade ticks
+  and trade-derived OHLCV bars.
+
 ### Repository Maintenance
 
 - Consolidated the root changelog files into this single `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,16 @@ data = bt.feeds.YahooFinanceData(
     fromdate=datetime(2020, 1, 1),
     todate=datetime(2023, 12, 31),
 )
+
+# Option 4: Load exchange-native crypto history from CryptoHFTData
+# Install first with: pip install -e '.[cryptohftdata]'
+data = bt.feeds.CryptoHFTData(
+    dataname='BTCUSDT',
+    exchange='binance_futures',
+    fromdate=datetime(2026, 7, 1),
+    todate=datetime(2026, 7, 2),
+    timeframe=bt.TimeFrame.Minutes,
+)
 ```
 
 ### Step 4: Run Backtest

--- a/backtrader/feeds/__init__.py
+++ b/backtrader/feeds/__init__.py
@@ -38,6 +38,7 @@ else:
     from .btapifeed import BtApiFeed as BtApiFeed
     from .btcsv import *
     from .chainer import Chainer as Chainer
+    from .cryptohftdata import CryptoHFTData as CryptoHFTData
     from .csvgeneric import *
     from .influxfeed import *
     from .mixed_channel import MixedChannel as MixedChannel

--- a/backtrader/feeds/cryptohftdata.py
+++ b/backtrader/feeds/cryptohftdata.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+"""Historical cryptocurrency data feed backed by CryptoHFTData."""
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator
+
+import pandas as pd
+
+from ..dataseries import TimeFrame
+from ..feed import DataBase
+from ..utils import date2num
+
+__all__ = ["CryptoHFTData"]
+
+
+_TIMEFRAME_RULES = {
+    TimeFrame.Seconds: "s",
+    TimeFrame.Minutes: "min",
+    TimeFrame.Days: "D",
+}
+
+
+class CryptoHFTData(DataBase):
+    """Load historical exchange trades from CryptoHFTData.
+
+    Tick requests emit one OHLCV-shaped backtrader bar per trade. Second,
+    minute, and daily requests aggregate the same trades into UTC-aligned
+    bars. Use ``TimeFrame.Minutes`` with ``compression=60`` for hourly bars.
+
+    ``fromdate`` and ``todate`` are required to avoid accidental unbounded
+    high-frequency downloads. Naive datetimes are interpreted as UTC.
+    """
+
+    params = (
+        ("exchange", None),
+        ("api_key", None),
+        ("client", None),
+        ("timeframe", TimeFrame.Minutes),
+        ("compression", 1),
+    )
+
+    def __init__(self):
+        """Initialize an empty historical row iterator."""
+        super().__init__()
+        self._rows: Iterator[Dict[str, Any]] = iter(())
+
+    def start(self):
+        """Download the requested trades and prepare chronological bars."""
+        super().start()
+        if not self.p.dataname:
+            raise ValueError("CryptoHFTData requires dataname to be a symbol such as BTCUSDT")
+        if not self.p.exchange:
+            raise ValueError("CryptoHFTData requires an exchange such as binance_futures")
+        if self.p.fromdate is None or self.p.todate is None:
+            raise ValueError("CryptoHFTData requires both fromdate and todate")
+        if self.p.compression < 1:
+            raise ValueError("CryptoHFTData compression must be at least 1")
+
+        start = _as_utc(self.p.fromdate)
+        end = _as_utc(self.p.todate)
+        if end < start:
+            raise ValueError("CryptoHFTData todate must not precede fromdate")
+
+        client = self.p.client or self._create_client()
+        trades = client.get_trades(
+            symbol=str(self.p.dataname).upper(),
+            exchange=self.p.exchange,
+            start_date=start.date().isoformat(),
+            end_date=end.date().isoformat(),
+        )
+        self._rows = iter(self._prepare_rows(trades, start, end))
+
+    def _create_client(self):
+        """Create the optional CryptoHFTData SDK client lazily."""
+        try:
+            from cryptohftdata import CryptoHFTDataClient
+        except ImportError as exc:
+            raise ImportError(
+                "CryptoHFTData feed requires the optional dependency; "
+                "install backtrader[cryptohftdata]"
+            ) from exc
+
+        api_key = self.p.api_key or os.getenv("CRYPTOHFTDATA_API_KEY") or None
+        return CryptoHFTDataClient(api_key=api_key)
+
+    def _prepare_rows(self, trades, start: datetime, end: datetime):
+        """Normalize SDK trades and optionally aggregate them into bars."""
+        required = {"trade_time", "trade_id", "price", "quantity"}
+        missing = required.difference(trades.columns)
+        if missing:
+            raise ValueError(
+                "CryptoHFTData response is missing required columns: " + ", ".join(sorted(missing))
+            )
+        if trades.empty:
+            return []
+
+        frame = trades.copy()
+        frame["datetime"] = pd.to_datetime(frame["trade_time"], unit="ms", utc=True)
+        frame["price"] = pd.to_numeric(frame["price"], errors="coerce")
+        frame["quantity"] = pd.to_numeric(frame["quantity"], errors="coerce")
+        frame = frame.dropna(subset=["datetime", "price", "quantity"])
+        frame = frame.loc[
+            (frame["datetime"] >= pd.Timestamp(start)) & (frame["datetime"] <= pd.Timestamp(end))
+        ]
+        frame = frame.sort_values(["trade_time", "trade_id"], kind="stable")
+
+        if self.p.timeframe == TimeFrame.Ticks:
+            frame = frame.assign(
+                open=frame["price"],
+                high=frame["price"],
+                low=frame["price"],
+                close=frame["price"],
+                volume=frame["quantity"],
+            )
+            return frame[["datetime", "open", "high", "low", "close", "volume"]].to_dict("records")
+
+        suffix = _TIMEFRAME_RULES.get(self.p.timeframe)
+        if suffix is None:
+            name = TimeFrame.getname(self.p.timeframe, self.p.compression)
+            raise ValueError(f"CryptoHFTData does not support the {name} timeframe")
+        rule = f"{self.p.compression}{suffix}"
+        bars = (
+            frame.set_index("datetime")
+            .resample(rule, label="left", closed="left")
+            .agg(
+                open=("price", "first"),
+                high=("price", "max"),
+                low=("price", "min"),
+                close=("price", "last"),
+                volume=("quantity", "sum"),
+            )
+            .dropna(subset=["open"])
+            .reset_index()
+        )
+        return bars.to_dict("records")
+
+    def _load(self):
+        """Emit the next normalized trade or bar."""
+        try:
+            row = next(self._rows)
+        except StopIteration:
+            return False
+
+        timestamp = row["datetime"].to_pydatetime().astimezone(timezone.utc).replace(tzinfo=None)
+        self.lines.datetime[0] = date2num(timestamp)
+        self.lines.open[0] = float(row["open"])
+        self.lines.high[0] = float(row["high"])
+        self.lines.low[0] = float(row["low"])
+        self.lines.close[0] = float(row["close"])
+        self.lines.volume[0] = float(row["volume"])
+        self.lines.openinterest[0] = 0.0
+        return True
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Return an aware UTC datetime, interpreting naive values as UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/docs/source/tutorials/notebooks/05_cryptohftdata.ipynb
+++ b/docs/source/tutorials/notebooks/05_cryptohftdata.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Backtest CryptoHFTData history\n",
+    "\n",
+    "This notebook loads exchange-native historical trades through Backtrader's `CryptoHFTData` feed and aggregates them into one-minute OHLCV bars. Install the optional dependency with `pip install -e '.[cryptohftdata]'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "import backtrader as bt\n",
+    "\n",
+    "data = bt.feeds.CryptoHFTData(\n",
+    "    dataname='BTCUSDT',\n",
+    "    exchange='binance_futures',\n",
+    "    fromdate=datetime(2026, 7, 1),\n",
+    "    todate=datetime(2026, 7, 2),\n",
+    "    timeframe=bt.TimeFrame.Minutes,\n",
+    ")\n",
+    "cerebro = bt.Cerebro()\n",
+    "cerebro.adddata(data)\n",
+    "results = cerebro.run()\n",
+    "len(data), data.close[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user-guide/data_feeds.rst
+++ b/docs/source/user-guide/data_feeds.rst
@@ -131,6 +131,36 @@ Yahoo Finance 格式
    
    data = bt.feeds.PandasData(dataname=df)
 
+CryptoHFTData 加密货币历史数据
+-----------------------------
+
+安装可选依赖后，可以直接将交易所原生历史成交加载为 tick 或 UTC 对齐的 OHLCV bar：
+
+.. code-block:: bash
+
+   pip install -e '.[cryptohftdata]'
+
+.. code-block:: python
+
+   import datetime
+   import backtrader as bt
+
+   data = bt.feeds.CryptoHFTData(
+       dataname='BTCUSDT',
+       exchange='binance_futures',
+       fromdate=datetime.datetime(2026, 7, 1),
+       todate=datetime.datetime(2026, 7, 2),
+       timeframe=bt.TimeFrame.Minutes,
+       compression=1,
+       api_key=None,  # 可选；也可以设置 CRYPTOHFTDATA_API_KEY
+   )
+   cerebro.adddata(data)
+
+``fromdate`` 和 ``todate`` 必须提供；无时区时间按 UTC 解释。``TimeFrame.Ticks``
+为每笔成交生成一条记录，Seconds/Minutes/Days 会从成交聚合 OHLCV；小时 bar 使用
+``TimeFrame.Minutes`` 和 ``compression=60``。CryptoHFTData 的深度订单簿是序列化增量，
+不能无损映射到 Backtrader 的标准 OHLCV lines，因此该 feed 仅提供成交历史。
+
 自定义列映射：
 
 .. code-block:: python

--- a/examples/cryptohftdata_sma.py
+++ b/examples/cryptohftdata_sma.py
@@ -1,0 +1,42 @@
+"""Run a simple moving-average backtest on CryptoHFTData minute bars."""
+
+from datetime import datetime
+
+import backtrader as bt
+
+
+class MovingAverageCross(bt.Strategy):
+    """Trade when the fast moving average crosses the slow average."""
+
+    def __init__(self):
+        fast = bt.indicators.SMA(self.data.close, period=10)
+        slow = bt.indicators.SMA(self.data.close, period=30)
+        self.cross = bt.indicators.CrossOver(fast, slow)
+
+    def next(self):
+        """Submit crossover orders."""
+        if not self.position and self.cross[0] > 0:
+            self.buy()
+        elif self.position and self.cross[0] < 0:
+            self.close()
+
+
+def main():
+    """Configure CryptoHFTData and run the example backtest."""
+    cerebro = bt.Cerebro()
+    cerebro.adddata(
+        bt.feeds.CryptoHFTData(
+            dataname="BTCUSDT",
+            exchange="binance_futures",
+            fromdate=datetime(2026, 7, 1),
+            todate=datetime(2026, 7, 2),
+            timeframe=bt.TimeFrame.Minutes,
+        )
+    )
+    cerebro.addstrategy(MovingAverageCross)
+    cerebro.run()
+    print(f"final portfolio value: {cerebro.broker.getvalue():.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             "dash",
             "pyecharts",
         ],
+        "cryptohftdata": ["cryptohftdata>=0.4.0,<1.0.0"],
     },  # List of project dependencies
     python_requires=">=3.8",
     classifiers=[

--- a/tests/unit/feeds/test_cryptohftdata.py
+++ b/tests/unit/feeds/test_cryptohftdata.py
@@ -1,0 +1,126 @@
+"""Tests for the CryptoHFTData historical feed."""
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+import backtrader as bt
+
+
+class StubClient:
+    """Return deterministic CryptoHFTData SDK-shaped trades."""
+
+    def __init__(self, trades):
+        self.trades = trades
+        self.calls = []
+
+    def get_trades(self, **kwargs):
+        """Record the query and return a copy of the fixture."""
+        self.calls.append(kwargs)
+        return self.trades.copy()
+
+
+def _trades():
+    start = datetime(2026, 7, 11, tzinfo=timezone.utc)
+    return pd.DataFrame(
+        [
+            _trade(start, 1, "10", "2"),
+            _trade(start.replace(second=20), 2, "12", "3"),
+            _trade(start.replace(second=40), 3, "9", "4"),
+            _trade(start.replace(minute=1), 4, "11", "5"),
+        ]
+    )
+
+
+def _trade(timestamp, trade_id, price, quantity):
+    return {
+        "trade_time": int(timestamp.timestamp() * 1000),
+        "trade_id": trade_id,
+        "price": price,
+        "quantity": quantity,
+        "is_buyer_maker": False,
+    }
+
+
+def _load_feed(client, **kwargs):
+    data = bt.feeds.CryptoHFTData(
+        dataname="KAVAUSDT",
+        exchange="binance_futures",
+        fromdate=datetime(2026, 7, 11),
+        todate=datetime(2026, 7, 11, 0, 2),
+        client=client,
+        **kwargs,
+    )
+    data._start()
+    rows = []
+    while data.load():
+        rows.append(
+            {
+                "datetime": data.datetime.datetime(0),
+                "open": data.open[0],
+                "high": data.high[0],
+                "low": data.low[0],
+                "close": data.close[0],
+                "volume": data.volume[0],
+            }
+        )
+    return data, rows
+
+
+def test_minute_feed_downloads_and_aggregates_trades():
+    """Minute bars preserve UTC OHLCV semantics and query parameters."""
+    client = StubClient(_trades())
+    _data, rows = _load_feed(client, timeframe=bt.TimeFrame.Minutes)
+
+    assert client.calls == [
+        {
+            "symbol": "KAVAUSDT",
+            "exchange": "binance_futures",
+            "start_date": "2026-07-11",
+            "end_date": "2026-07-11",
+        }
+    ]
+    assert len(rows) == 2
+    assert rows[0] == {
+        "datetime": datetime(2026, 7, 11),
+        "open": 10.0,
+        "high": 12.0,
+        "low": 9.0,
+        "close": 9.0,
+        "volume": 9.0,
+    }
+
+
+def test_tick_feed_emits_one_bar_per_trade():
+    """Tick mode exposes every historical trade without aggregation."""
+    _data, rows = _load_feed(StubClient(_trades()), timeframe=bt.TimeFrame.Ticks)
+
+    assert len(rows) == 4
+    assert rows[0]["open"] == rows[0]["close"] == 10.0
+    assert rows[0]["volume"] == 2.0
+
+
+def test_feed_requires_bounded_dates():
+    """A bounded range is mandatory for high-frequency downloads."""
+    data = bt.feeds.CryptoHFTData(
+        dataname="BTCUSDT", exchange="binance_futures", client=StubClient(_trades())
+    )
+
+    with pytest.raises(ValueError, match="both fromdate and todate"):
+        data._start()
+
+
+def test_feed_rejects_unsupported_timeframe():
+    """Weekly requests fail clearly instead of silently misaggregating."""
+    data = bt.feeds.CryptoHFTData(
+        dataname="BTCUSDT",
+        exchange="binance_futures",
+        fromdate=datetime(2026, 7, 11),
+        todate=datetime(2026, 7, 12),
+        timeframe=bt.TimeFrame.Weeks,
+        client=StubClient(_trades()),
+    )
+
+    with pytest.raises(ValueError, match="does not support"):
+        data._start()


### PR DESCRIPTION
## 变更说明

Adds CryptoHFTData as a first-class historical feed for exchange-native cryptocurrency trades. I maintain CryptoHFTData and am contributing this adapter so Backtrader users can load the provider through the normal `bt.feeds` API.

- exposes `bt.feeds.CryptoHFTData` with optional API-key or keyless SDK access
- emits individual trades in tick mode and UTC-aligned OHLCV bars at second, minute, and daily resolutions
- requires bounded dates to prevent accidental unbounded high-frequency downloads
- adds the `cryptohftdata` optional dependency group
- includes user-guide and README documentation, an example strategy, and a tutorial notebook
- documents why sequenced arbitrary-depth order-book updates are not flattened into standard OHLCV lines

## 变更类型

- [x] 新功能
- [x] 文档更新

## 测试

- `.venv/bin/python -m pytest tests -m "not slow" -n 8 -q` — 2456 passed, 14 skipped
- `python3 -m pytest tests/unit/feeds/test_cryptohftdata.py -q` — 4 passed
- live keyless SDK validation — 50 non-empty KAVAUSDT minute bars loaded for 2026-07-11 00:00–00:59 UTC
- Black check passed for changed Python files
- Ruff passed for changed Python files
- Pylint rated the new feed 10.00/10
- source distribution and wheel built successfully

The repository-level `make format-check` target currently references the absent `tests/original_tests` directory on `dev`; the changed files pass the equivalent focused Black check.